### PR TITLE
Fix svg className attribute

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,9 @@ const createTextElement = (text) => !is.text(text) ? undefined : {
 const considerSvg = (vnode) => !is.svg(vnode) ? vnode :
   fn.assign(vnode,
     { data: fn.omit('props', fn.extend(vnode.data,
-      { ns: 'http://www.w3.org/2000/svg', attrs: vnode.data.props }
+      { ns: 'http://www.w3.org/2000/svg', attrs: fn.omit('className', fn.extend(vnode.data.props,
+        { class: vnode.data.props ? vnode.data.props.className : undefined }
+      )) }
     )) },
     { children: is.undefinedv(vnode.children) ? undefined :
       vnode.children.map((child) => considerSvg(child))


### PR DESCRIPTION
`<XXX class='something' />`
is not valid JSX, currently this is the only way to add a class on SVG elements
This fixes this, that you can additionally use
`<XXX className='something' />`

I tested locally, everything works as expected