### PR TITLE
Split only the first dash in deepifyKeys

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
-    "buble": "^0.15.2",
+    "buble": "^0.17.3",
     "eslint-config-xo-swizz": "^0.11.0",
     "rimraf": "^2.6.1",
     "rollup": "^0.41.3",

--- a/src/fn.js
+++ b/src/fn.js
@@ -29,10 +29,18 @@ export const mapObject = (obj, fn) => entries(obj).map(
 )
 
 export const deepifyKeys = (obj) => mapObject(obj,
-  ([key, val]) => key.split('-').reverse().reduce(
-    (object, key) => ({ [key]: object }),
-    val
-  )
+  ([key, val]) => {
+    let dashIndex = key.indexOf('-')
+    if (dashIndex > -1) {
+      return {
+        [key.slice(0, dashIndex)]: {
+          [key.slice(dashIndex + 1)]: val
+        }
+      }
+    } else {
+      return {[key]: val}
+    }
+  }
 )
 
 export const renameMod = (name) => {

--- a/src/fn.js
+++ b/src/fn.js
@@ -30,16 +30,15 @@ export const mapObject = (obj, fn) => entries(obj).map(
 
 export const deepifyKeys = (obj) => mapObject(obj,
   ([key, val]) => {
-    let dashIndex = key.indexOf('-')
+    const dashIndex = key.indexOf('-')
     if (dashIndex > -1) {
       return {
         [key.slice(0, dashIndex)]: {
           [key.slice(dashIndex + 1)]: val
         }
       }
-    } else {
-      return {[key]: val}
     }
+    return { [key]: val }
   }
 )
 

--- a/src/fn.js
+++ b/src/fn.js
@@ -32,10 +32,11 @@ export const deepifyKeys = (obj) => mapObject(obj,
   ([key, val]) => {
     const dashIndex = key.indexOf('-')
     if (dashIndex > -1) {
+      const moduleData = {
+        [key.slice(dashIndex + 1)]: val
+      }
       return {
-        [key.slice(0, dashIndex)]: {
-          [key.slice(dashIndex + 1)]: val
-        }
+        [key.slice(0, dashIndex)]: moduleData
       }
     }
     return { [key]: val }

--- a/test/snabbdom-specs/vnode-class-names/actual.js
+++ b/test/snabbdom-specs/vnode-class-names/actual.js
@@ -2,5 +2,5 @@
 import { isVisible, isEnabled } from './neutral'
 
 export default (createElement) => {
-  return createElement('div', { 'class-visible': isVisible, 'class-enabled': isEnabled })
+  return createElement('div', { 'class-visible': isVisible, 'class-enabled': isEnabled, 'class-alert-danger': true })
 }

--- a/test/snabbdom-specs/vnode-class-names/expected.js
+++ b/test/snabbdom-specs/vnode-class-names/expected.js
@@ -3,6 +3,6 @@ import { isVisible, isEnabled } from './neutral'
 
 export default (h) => {
   return h('div', {
-    class: { visible: isVisible, enabled: isEnabled }
+    class: { visible: isVisible, enabled: isEnabled, 'alert-danger': true }
   }, [])
 }

--- a/test/snabbdom-specs/vnode-style/actual.js
+++ b/test/snabbdom-specs/vnode-style/actual.js
@@ -1,4 +1,4 @@
 
 export default (createElement) => {
-  return createElement('div', { 'style-color': 'red' })
+  return createElement('div', { 'style-color': 'red', 'style-background-color': 'blue' })
 }

--- a/test/snabbdom-specs/vnode-style/expected.js
+++ b/test/snabbdom-specs/vnode-style/expected.js
@@ -1,6 +1,6 @@
 
 export default (h) => {
   return h('div', {
-    style: { color: 'red' }
+    style: { color: 'red', 'background-color': 'blue' }
   }, [])
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,19 +47,23 @@ acorn-jsx@^3.0.0, acorn-jsx@^3.0.1:
   dependencies:
     acorn "^3.0.4"
 
-acorn-object-spread@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-object-spread/-/acorn-object-spread-1.0.0.tgz#48ead0f4a8eb16995a17a0db9ffc6acaada4ba68"
+acorn5-object-spread@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/acorn5-object-spread/-/acorn5-object-spread-4.0.0.tgz#d5758081eed97121ab0be47e31caaef2aa399697"
   dependencies:
-    acorn "^3.1.0"
+    acorn "^5.1.2"
 
-acorn@^3.0.4, acorn@^3.1.0, acorn@^3.3.0:
+acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
 acorn@^5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
+
+acorn@^5.1.2:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
 
 ajv-keywords@^1.0.0:
   version "1.5.1"
@@ -105,6 +109,12 @@ ansi-styles@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.0.0.tgz#5404e93a544c4fec7f048262977bebfe3155e0c1"
   dependencies:
     color-convert "^1.0.0"
+
+ansi-styles@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
 
 ansi-styles@~1.0.0:
   version "1.0.0"
@@ -944,17 +954,18 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-buble@^0.15.2:
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/buble/-/buble-0.15.2.tgz#547fc47483f8e5e8176d82aa5ebccb183b02d613"
+buble@^0.17.3:
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/buble/-/buble-0.17.3.tgz#b30e281054aa619da5e7b0530ac99fcf309bee67"
   dependencies:
-    acorn "^3.3.0"
+    acorn "^5.1.2"
     acorn-jsx "^3.0.1"
-    acorn-object-spread "^1.0.0"
-    chalk "^1.1.3"
-    magic-string "^0.14.0"
+    acorn5-object-spread "^4.0.0"
+    chalk "^2.1.0"
+    magic-string "^0.22.4"
     minimist "^1.2.0"
     os-homedir "^1.0.1"
+    vlq "^0.2.2"
 
 buf-compare@^1.0.0:
   version "1.0.1"
@@ -1039,6 +1050,14 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
 
 chokidar@^1.4.2:
   version "1.6.1"
@@ -1125,6 +1144,12 @@ code-point-at@^1.0.0:
 color-convert@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  dependencies:
+    color-name "^1.1.1"
+
+color-convert@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
   dependencies:
     color-name "^1.1.1"
 
@@ -2715,9 +2740,9 @@ lru-cache@^4.0.0, lru-cache@^4.0.1:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-magic-string@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.14.0.tgz#57224aef1701caeed273b17a39a956e72b172462"
+magic-string@^0.22.4:
+  version "0.22.4"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.4.tgz#31039b4e40366395618c1d6cf8193c53917475ff"
   dependencies:
     vlq "^0.2.1"
 
@@ -3703,6 +3728,12 @@ supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
+supports-color@^4.0.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  dependencies:
+    has-flag "^2.0.0"
+
 symbol-observable@^0.2.2:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
@@ -3937,6 +3968,10 @@ verror@1.3.6:
 vlq@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.2.tgz#e316d5257b40b86bb43cb8d5fea5d7f54d6b0ca1"
+
+vlq@^0.2.2:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
 
 which@^1.2.8, which@^1.2.9:
   version "1.2.14"


### PR DESCRIPTION
Fixes #26 

Change `deepifyKeys` to split only the first dash, so is possible to pass properties with dashes to modules when using `MODULE-PROPERTY` attributes. 
