### PR TITLE
Add scripts to compare performance between two branches

### DIFF
--- a/dist/index.es6.js
+++ b/dist/index.es6.js
@@ -68,11 +68,15 @@ var deepifyKeys = function (obj) { return mapObject(obj,
     var key = ref[0];
     var val = ref[1];
 
-    return key.split('-').reverse().reduce(
-    function (object$$1, key) { return (( obj = {}, obj[key] = object$$1, obj ))
-      var obj; },
-    val
-  );
+    var dashIndex = key.indexOf('-');
+    if (dashIndex > -1) {
+      var moduleData = {};
+      moduleData[key.slice(dashIndex + 1)] = val;
+      return ( obj = {}, obj[key.slice(0, dashIndex)] = moduleData, obj )
+      var obj;
+    }
+    return ( obj$1 = {}, obj$1[key] = val, obj$1 )
+    var obj$1;
   }
 ); };
 
@@ -203,10 +207,10 @@ var sanitizeChildren = function (children) { return !array(children) || text(san
   ); };
 
 var createElement = function (sel, data) {
+  if ( data === void 0 ) data = {};
   var children = [], len = arguments.length - 2;
   while ( len-- > 0 ) children[ len ] = arguments[ len + 2 ];
 
-  if ( data === void 0 ) data = {};
   return fun(sel) ? sel(data, children) : considerSvg({
   sel: sel,
   data: sanitizeData(data),

--- a/dist/index.js
+++ b/dist/index.js
@@ -74,11 +74,15 @@ var deepifyKeys = function (obj) { return mapObject(obj,
     var key = ref[0];
     var val = ref[1];
 
-    return key.split('-').reverse().reduce(
-    function (object$$1, key) { return (( obj = {}, obj[key] = object$$1, obj ))
-      var obj; },
-    val
-  );
+    var dashIndex = key.indexOf('-');
+    if (dashIndex > -1) {
+      var moduleData = {};
+      moduleData[key.slice(dashIndex + 1)] = val;
+      return ( obj = {}, obj[key.slice(0, dashIndex)] = moduleData, obj )
+      var obj;
+    }
+    return ( obj$1 = {}, obj$1[key] = val, obj$1 )
+    var obj$1;
   }
 ); };
 
@@ -209,10 +213,10 @@ var sanitizeChildren = function (children) { return !array(children) || text(san
   ); };
 
 var createElement = function (sel, data) {
+  if ( data === void 0 ) data = {};
   var children = [], len = arguments.length - 2;
   while ( len-- > 0 ) children[ len ] = arguments[ len + 2 ];
 
-  if ( data === void 0 ) data = {};
   return fun(sel) ? sel(data, children) : considerSvg({
   sel: sel,
   data: sanitizeData(data),

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "clean": "./node_modules/.bin/rimraf 'lib/'",
     "build": "npm run transpile && npm run modules && npm run clean",
     "make": "npm run lint && npm run test:prebuild && npm run build && npm run test:postbuild",
-    "perf:all": "node perf/buildBranches && node perf/run",
+    "perf:all": "node perf/build-branches && node perf/run",
     "perf": "node perf/run"
   },
   "ava": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
+    "benchmark": "^2.1.4",
     "buble": "^0.17.3",
     "eslint-config-xo-swizz": "^0.11.0",
     "rimraf": "^2.6.1",
@@ -41,7 +42,7 @@
     "test:prebuild": "./node_modules/.bin/ava --match 'trans -*' --match 'src -*'",
     "test:postbuild": "./node_modules/.bin/ava --match 'dist -*'",
     "transpile": "./node_modules/.bin/buble -i src/ -o lib/ --no modules --objectAssign fn.assign",
-    "modules": "./node_modules/.bin/rollup -i lib/index.js -o dist/index.js -f cjs && ./node_modules/.bin/rollup -i lib/index.js -o dist/index.es6.js -f es",
+    "modules": "rollup -i lib/index.js -o dist/index.js -f cjs && rollup -i lib/index.js -o dist/index.es6.js -f es",
     "clean": "./node_modules/.bin/rimraf 'lib/'",
     "build": "npm run transpile && npm run modules && npm run clean",
     "make": "npm run lint && npm run test:prebuild && npm run build && npm run test:postbuild"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
-    "buble": "^0.15.2",
+    "buble": "^0.17.3",
     "eslint-config-xo-swizz": "^0.11.0",
     "rimraf": "^2.6.1",
     "rollup": "^0.41.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-config-xo-swizz": "^0.11.0",
     "rimraf": "^2.6.1",
     "rollup": "^0.41.3",
+    "simple-git": "^1.92.0",
     "snabbdom": "^0.6.7",
     "traceur": "^0.0.111",
     "typescript": "^2.3.2",
@@ -45,7 +46,9 @@
     "modules": "rollup -i lib/index.js -o dist/index.js -f cjs && rollup -i lib/index.js -o dist/index.es6.js -f es",
     "clean": "./node_modules/.bin/rimraf 'lib/'",
     "build": "npm run transpile && npm run modules && npm run clean",
-    "make": "npm run lint && npm run test:prebuild && npm run build && npm run test:postbuild"
+    "make": "npm run lint && npm run test:prebuild && npm run build && npm run test:postbuild",
+    "perf:all": "node perf/buildBranches && node perf/run",
+    "perf": "node perf/run"
   },
   "ava": {
     "files": [

--- a/perf/.gitignore
+++ b/perf/.gitignore
@@ -1,0 +1,2 @@
+/snnabdom-new.js
+/snnabdom-base.js

--- a/perf/build-branches.js
+++ b/perf/build-branches.js
@@ -1,11 +1,13 @@
-const execSync = require('child_process').execSync
-const fs = require('fs');
-const simpleGit = require('simple-git')();
+/* eslint unicorn/no-process-exit: 0 */
 
-let baseBranch =  process.argv[2] || 'develop'
+const execSync = require('child_process').execSync
+const fs = require('fs')
+const simpleGit = require('simple-git')()
+
+const baseBranch = process.argv[2] || 'develop'
 
 function buildSnabbdom(suffix) {
-  execSync('npm run build', {stdio: [0, 1, 2]});
+  execSync('npm run build', { stdio: [0, 1, 2] })
   fs.writeFileSync(`perf/snnabdom-${suffix}.js`, fs.readFileSync('dist/index.js', 'utf-8'), 'utf-8')
 }
 
@@ -21,18 +23,18 @@ simpleGit.status((err, status) => {
     } else {
       console.log('Building ' + currentBranch + ' branch')
       buildSnabbdom('new')
-      simpleGit.checkout(baseBranch, (err, data) => {
+      simpleGit.checkout(baseBranch, (err) => {
         if (err) {
           console.error('Error checkout ' + baseBranch)
         } else {
           console.log('Building ' + baseBranch + ' branch')
-          buildSnabbdom('base')          
+          buildSnabbdom('base')
         }
         simpleGit.checkout(currentBranch)
         if (err) {
           process.exit(1)
         }
       })
-    }  
+    }
   }
 })

--- a/perf/buildBranches.js
+++ b/perf/buildBranches.js
@@ -2,7 +2,7 @@ const execSync = require('child_process').execSync
 const fs = require('fs');
 const simpleGit = require('simple-git')();
 
-const baseBranch = 'develop'
+let baseBranch =  process.argv[2] || 'develop'
 
 function buildSnabbdom(suffix) {
   execSync('npm run build', {stdio: [0, 1, 2]});
@@ -12,19 +12,26 @@ function buildSnabbdom(suffix) {
 simpleGit.status((err, status) => {
   if (err) {
     console.error('Error getting status')
+    process.exit(1)
   } else {
     const currentBranch = status.current
     if (currentBranch === baseBranch) {
-      console.warn('Current branch is already ' + baseBranch)
+      console.error('Current branch is already ' + baseBranch)
+      process.exit(1)
     } else {
+      console.log('Building ' + currentBranch + ' branch')
       buildSnabbdom('new')
       simpleGit.checkout(baseBranch, (err, data) => {
         if (err) {
           console.error('Error checkout ' + baseBranch)
         } else {
+          console.log('Building ' + baseBranch + ' branch')
           buildSnabbdom('base')          
         }
         simpleGit.checkout(currentBranch)
+        if (err) {
+          process.exit(1)
+        }
       })
     }  
   }

--- a/perf/buildBranches.js
+++ b/perf/buildBranches.js
@@ -1,0 +1,31 @@
+const execSync = require('child_process').execSync
+const fs = require('fs');
+const simpleGit = require('simple-git')();
+
+const baseBranch = 'develop'
+
+function buildSnabbdom(suffix) {
+  execSync('npm run build', {stdio: [0, 1, 2]});
+  fs.writeFileSync(`perf/snnabdom-${suffix}.js`, fs.readFileSync('dist/index.js', 'utf-8'), 'utf-8')
+}
+
+simpleGit.status((err, status) => {
+  if (err) {
+    console.error('Error getting status')
+  } else {
+    const currentBranch = status.current
+    if (currentBranch === baseBranch) {
+      console.warn('Current branch is already ' + baseBranch)
+    } else {
+      buildSnabbdom('new')
+      simpleGit.checkout(baseBranch, (err, data) => {
+        if (err) {
+          console.error('Error checkout ' + baseBranch)
+        } else {
+          buildSnabbdom('base')          
+        }
+        simpleGit.checkout(currentBranch)
+      })
+    }  
+  }
+})

--- a/perf/modules-attribute-props.js
+++ b/perf/modules-attribute-props.js
@@ -1,0 +1,36 @@
+var Benchmark = require('benchmark');
+var h = require('snabbdom/h').default;
+var baseCreateElement = require('./snnabdom-base').createElement
+var newCreateElement = require('./snnabdom-new').createElement
+
+const isVisible = true
+const isEnabled = false
+
+function attributePropsHyper () {
+  return h('div', {dataset: { color: 'red' }, attrs: { 'aria-hidden': true }}, [
+    h('span', {style: { color: 'red', 'background-color': 'blue' }}, 'Hello'),
+    h('span', {class: { visible: isVisible, enabled: isEnabled, 'alert-danger': true }}, 'World')
+  ])
+}
+
+function attributeProps (createElement) {
+  return createElement('div', { 'data-color': 'red', 'aria-hidden': true }, [
+    createElement('span', { 'style-color': 'red', 'style-background-color': 'blue' }, 'Hello'),
+    createElement('span', { 'class-visible': isVisible, 'class-enabled': isEnabled, 'class-alert-danger': true }, 'World')
+  ])
+}
+
+var suite = new Benchmark.Suite('modules attribute props');
+
+// add tests
+suite.add('hyperscript', function() {
+  attributePropsHyper()
+})
+.add('jsx-base', function() {
+  attributeProps(baseCreateElement)
+})
+.add('jsx-new', function() {
+  attributeProps(newCreateElement)
+});
+
+module.exports = suite

--- a/perf/modules-attribute-props.js
+++ b/perf/modules-attribute-props.js
@@ -1,36 +1,38 @@
-var Benchmark = require('benchmark');
-var h = require('snabbdom/h').default;
-var baseCreateElement = require('./snnabdom-base').createElement
-var newCreateElement = require('./snnabdom-new').createElement
+/* eslint import/no-unresolved: 0 */
+
+const Benchmark = require('benchmark')
+const h = require('snabbdom/h').default
+const baseCreateElement = require('./snnabdom-base').createElement
+const newCreateElement = require('./snnabdom-new').createElement
 
 const isVisible = true
 const isEnabled = false
 
-function attributePropsHyper () {
-  return h('div', {dataset: { color: 'red' }, attrs: { 'aria-hidden': true }}, [
-    h('span', {style: { color: 'red', 'background-color': 'blue' }}, 'Hello'),
-    h('span', {class: { visible: isVisible, enabled: isEnabled, 'alert-danger': true }}, 'World')
+function attributePropsHyper() {
+  return h('div', { dataset: { color: 'red' }, attrs: { 'aria-hidden': true } }, [
+    h('span', { style: { color: 'red', 'background-color': 'blue' } }, 'Hello'),
+    h('span', { class: { visible: isVisible, enabled: isEnabled, 'alert-danger': true } }, 'World')
   ])
 }
 
-function attributeProps (createElement) {
+function attributeProps(createElement) {
   return createElement('div', { 'data-color': 'red', 'aria-hidden': true }, [
     createElement('span', { 'style-color': 'red', 'style-background-color': 'blue' }, 'Hello'),
     createElement('span', { 'class-visible': isVisible, 'class-enabled': isEnabled, 'class-alert-danger': true }, 'World')
   ])
 }
 
-var suite = new Benchmark.Suite('modules attribute props');
+const suite = new Benchmark.Suite('modules attribute props')
 
 // add tests
-suite.add('hyperscript', function() {
+suite.add('hyperscript', () => {
   attributePropsHyper()
-})
-.add('jsx-base', function() {
+}).
+add('jsx-base', () => {
   attributeProps(baseCreateElement)
-})
-.add('jsx-new', function() {
+}).
+add('jsx-new', () => {
   attributeProps(newCreateElement)
-});
+})
 
 module.exports = suite

--- a/perf/modules-object-props.js
+++ b/perf/modules-object-props.js
@@ -1,0 +1,33 @@
+var Benchmark = require('benchmark');
+var h = require('snabbdom/h').default;
+var baseCreateElement = require('./snnabdom-base').createElement
+var newCreateElement = require('./snnabdom-new').createElement
+
+function objectPropsHyper () {
+  return h('div', { style: { color: 'red', fontWeight: 'bold' }, dataset: { color: 'red', hidden: true } }, [
+    h('span', {attrs: {href: '/foo'}}, 'Hello'),
+    h('span', {dataset: {action: 'reset'}}, 'World')
+  ])
+}
+
+function objectProps (createElement) {
+  return createElement('div', { style: { color: 'red', fontWeight: 'bold' }, data: { color: 'red', hidden: true }}, [
+    createElement('span', {attrs: {href: '/foo'}}, 'Hello'),
+    createElement('span', {data: {action: 'reset'}}, 'World')
+  ])
+}
+
+var suite = new Benchmark.Suite('module object props');
+
+// add tests
+suite.add('hyperscript', function() {
+  objectPropsHyper()
+})
+.add('jsx-base', function() {
+  objectProps(baseCreateElement)
+})
+.add('jsx-new', function() {
+  objectProps(newCreateElement)
+});
+
+module.exports = suite

--- a/perf/modules-object-props.js
+++ b/perf/modules-object-props.js
@@ -1,33 +1,35 @@
-var Benchmark = require('benchmark');
-var h = require('snabbdom/h').default;
-var baseCreateElement = require('./snnabdom-base').createElement
-var newCreateElement = require('./snnabdom-new').createElement
+/* eslint import/no-unresolved: 0 */
 
-function objectPropsHyper () {
+const Benchmark = require('benchmark')
+const h = require('snabbdom/h').default
+const baseCreateElement = require('./snnabdom-base').createElement
+const newCreateElement = require('./snnabdom-new').createElement
+
+function objectPropsHyper() {
   return h('div', { style: { color: 'red', fontWeight: 'bold' }, dataset: { color: 'red', hidden: true } }, [
-    h('span', {attrs: {href: '/foo'}}, 'Hello'),
-    h('span', {dataset: {action: 'reset'}}, 'World')
+    h('span', { attrs: { href: '/foo' } }, 'Hello'),
+    h('span', { dataset: { action: 'reset' } }, 'World')
   ])
 }
 
-function objectProps (createElement) {
-  return createElement('div', { style: { color: 'red', fontWeight: 'bold' }, data: { color: 'red', hidden: true }}, [
-    createElement('span', {attrs: {href: '/foo'}}, 'Hello'),
-    createElement('span', {data: {action: 'reset'}}, 'World')
+function objectProps(createElement) {
+  return createElement('div', { style: { color: 'red', fontWeight: 'bold' }, data: { color: 'red', hidden: true } }, [
+    createElement('span', { attrs: { href: '/foo' } }, 'Hello'),
+    createElement('span', { data: { action: 'reset' } }, 'World')
   ])
 }
 
-var suite = new Benchmark.Suite('module object props');
+const suite = new Benchmark.Suite('module object props')
 
 // add tests
-suite.add('hyperscript', function() {
+suite.add('hyperscript', () => {
   objectPropsHyper()
-})
-.add('jsx-base', function() {
+}).
+add('jsx-base', () => {
   objectProps(baseCreateElement)
-})
-.add('jsx-new', function() {
+}).
+add('jsx-new', () => {
   objectProps(newCreateElement)
-});
+})
 
 module.exports = suite

--- a/perf/no-props.js
+++ b/perf/no-props.js
@@ -1,33 +1,35 @@
-var Benchmark = require('benchmark');
-var h = require('snabbdom/h').default;
-var baseCreateElement = require('./snnabdom-base').createElement
-var newCreateElement = require('./snnabdom-new').createElement
+/* eslint import/no-unresolved: 0 */
 
-function noPropsHyper () {
+const Benchmark = require('benchmark')
+const h = require('snabbdom/h').default
+const baseCreateElement = require('./snnabdom-base').createElement
+const newCreateElement = require('./snnabdom-new').createElement
+
+function noPropsHyper() {
   return h('div', {}, [
     h('span', {}, 'Hello'),
     h('span', {}, 'World')
   ])
 }
 
-function noProps (createElement) {
+function noProps(createElement) {
   return createElement('div', null, [
     createElement('span', null, 'Hello'),
     createElement('span', null, 'World')
   ])
 }
 
-var suite = new Benchmark.Suite('no props');
+const suite = new Benchmark.Suite('no props')
 
 // add tests
-suite.add('hyperscript', function() {
+suite.add('hyperscript', () => {
   noPropsHyper()
-})
-.add('jsx-base', function() {
+}).
+add('jsx-base', () => {
   noProps(baseCreateElement)
-})
-.add('jsx-new', function() {
+}).
+add('jsx-new', () => {
   noProps(newCreateElement)
-});
+})
 
 module.exports = suite

--- a/perf/no-props.js
+++ b/perf/no-props.js
@@ -1,0 +1,33 @@
+var Benchmark = require('benchmark');
+var h = require('snabbdom/h').default;
+var baseCreateElement = require('./snnabdom-base').createElement
+var newCreateElement = require('./snnabdom-new').createElement
+
+function noPropsHyper () {
+  return h('div', {}, [
+    h('span', {}, 'Hello'),
+    h('span', {}, 'World')
+  ])
+}
+
+function noProps (createElement) {
+  return createElement('div', null, [
+    createElement('span', null, 'Hello'),
+    createElement('span', null, 'World')
+  ])
+}
+
+var suite = new Benchmark.Suite('no props');
+
+// add tests
+suite.add('hyperscript', function() {
+  noPropsHyper()
+})
+.add('jsx-base', function() {
+  noProps(baseCreateElement)
+})
+.add('jsx-new', function() {
+  noProps(newCreateElement)
+});
+
+module.exports = suite

--- a/perf/real-world-form.js
+++ b/perf/real-world-form.js
@@ -1,179 +1,184 @@
-var Benchmark = require('benchmark');
-var baseCreateElement = require('./snnabdom-base').createElement
-var newCreateElement = require('./snnabdom-new').createElement
+/* eslint import/no-unresolved: 0 */
 
+const Benchmark = require('benchmark')
+const baseCreateElement = require('./snnabdom-base').createElement
+const newCreateElement = require('./snnabdom-new').createElement
 
 function realWorldForm(createElement) {
-  var state = {};
-  var patient = {get() {}};
-  var clinicalCalcs = {get() {}, isEmpty() {return false}, keys() {return ['a', 'b', 'c', 'd', 'e']}};
+  const state = {}
+  const patient = { get() {} }
+  const clinicalCalcs = {
+    get() {},
+    isEmpty() {return false},
+    keys() {return ['a', 'b', 'c', 'd', 'e']}
+  }
   return createElement(
-    "div",
-    { className: "page compact-content" },
+    'div',
+    { className: 'page compact-content' },
    createElement(
-      "div",
-      { className: "navbar" },
+      'div',
+      { className: 'navbar' },
      createElement(
-        "div",
-        { className: "navbar-inner" },
+        'div',
+        { className: 'navbar-inner' },
        createElement(
-          "div",
-          { className: "left" },
+          'div',
+          { className: 'left' },
          createElement(
-            "a",
-            { href: "#", className: "link icon-only back" },
-           createElement("i", { className: "icon icon-back" })
+            'a',
+            { href: '#', className: 'link icon-only back' },
+           createElement('i', { className: 'icon icon-back' })
           )
         ),
        createElement(
-          "div",
-          { className: "center sliding" },
-          "Exames do Paciente"
+          'div',
+          { className: 'center sliding' },
+          'Exames do Paciente'
         ),
-       createElement("div", { className: "right" })
+       createElement('div', { className: 'right' })
       )
     ),
    createElement(
-      "div",
-      { className: "page-content" },
+      'div',
+      { className: 'page-content' },
      createElement(
-        "div",
-        { className: "content-block" },
+        'div',
+        { className: 'content-block' },
        createElement(
-          "h3",
+          'h3',
           null,
-          patient.get('name'),          
-          " anos",
-         createElement("br", null),
+          patient.get('name'),
+          ' anos',
+         createElement('br', null),
          createElement(
-            "span",
-            { className: "header-subtitle" },
+            'span',
+            { className: 'header-subtitle' },
             patient.get('sectorname') || '',
-            " Leito ",
+            ' Leito ',
             (patient.get('bednumber') || '').padStart(2, '0')
           )
         )
       ),
      createElement(
-        "div",
-        { className: "content-block" },
+        'div',
+        { className: 'content-block' },
        createElement(
-          "div",
-          { className: "row" },
+          'div',
+          { className: 'row' },
          createElement(
-            "div",
-            { className: "col" },
+            'div',
+            { className: 'col' },
            createElement(
-              "b",
+              'b',
               null,
-              "Registro"
+              'Registro'
             ),
-           createElement("br", null),
+           createElement('br', null),
             patient.get('registry'),
-            " ",
-           createElement("br", null)
+            ' ',
+           createElement('br', null)
           ),
          createElement(
-            "div",
-            { className: "col" },
+            'div',
+            { className: 'col' },
            createElement(
-              "b",
+              'b',
               null,
-              "Admiss\xE3o Hospitalar"
+              'Admiss\xE3o Hospitalar'
             ),
-           createElement("br", null),           
-            " ",
-           createElement("br", null)
+           createElement('br', null),
+            ' ',
+           createElement('br', null)
           )
         )
       ),
      createElement(
-        "div",
-        { className: "list-block" },
+        'div',
+        { className: 'list-block' },
        createElement(
-          "ul",
+          'ul',
           null,
          createElement(
-            "li",
-            { id: "clinical-calcs", className: "accordion-item" },
+            'li',
+            { id: 'clinical-calcs', className: 'accordion-item' },
            createElement(
-              "a",
-              { href: "#", className: "item-content item-link" },
+              'a',
+              { href: '#', className: 'item-content item-link' },
              createElement(
-                "div",
-                { className: "item-inner" },
+                'div',
+                { className: 'item-inner' },
                createElement(
-                  "div",
-                  { className: "item-title" },
-                  "C\xE1lculos"
+                  'div',
+                  { className: 'item-title' },
+                  'C\xE1lculos'
                 )
               )
             ),
            createElement(
-              "div",
-              { className: "content-block" },
+              'div',
+              { className: 'content-block' },
              createElement(
-                "div",
-                { className: "accordion-item-content" },
+                'div',
+                { className: 'accordion-item-content' },
                 clinicalCalcs ? createElement(
-                  "div",
+                  'div',
                   null,
-                  " ",
+                  ' ',
                  createElement(
-                    "div",
-                    { className: "card-content" },
+                    'div',
+                    { className: 'card-content' },
                     !clinicalCalcs.isEmpty() ? createElement(
-                      "div",
-                      { className: "list-block media-list" },
-                      clinicalCalcs.keys().map(function (calcKey) {
+                      'div',
+                      { className: 'list-block media-list' },
+                      clinicalCalcs.keys().map((calcKey) => {
                         return createElement(
-                          "ul",
+                          'ul',
                           null,
                          createElement(
-                            "li",
+                            'li',
                             null,
                            createElement(
-                              "a",
-                              { href: "#", className: "item-link item-content calc-item", data: { calcKey: calcKey } },
+                              'a',
+                              { href: '#', className: 'item-link item-content calc-item', data: { calcKey } },
                              createElement(
-                                "div",
-                                { className: "item-inner" },
+                                'div',
+                                { className: 'item-inner' },
                                createElement(
-                                  "div",
-                                  { className: "item-title-row" },
+                                  'div',
+                                  { className: 'item-title-row' },
                                  createElement(
-                                    "div",
-                                    { className: "item-title" },
+                                    'div',
+                                    { className: 'item-title' },
                                     clinicalCalcs.get(calcKey)
                                   )
                                 ),
                                createElement(
-                                  "div",
-                                  { className: "item-text" },
+                                  'div',
+                                  { className: 'item-text' },
                                   clinicalCalcs.get(calcKey) || ''
                                 )
                               )
                             )
                           )
-                        );
+                        )
                       })
                     ) : 'Nenhum cálculo salvo'
                   ),
                  createElement(
-                    "div",
-                    { className: "card-footer" },
-                   createElement("div", null),
-                    " ",
+                    'div',
+                    { className: 'card-footer' },
+                   createElement('div', null),
+                    ' ',
                    createElement(
-                      "a",
-                      { href: "#", id: "add-calc-item", className: "link" },
-                      "Adicionar"
+                      'a',
+                      { href: '#', id: 'add-calc-item', className: 'link' },
+                      'Adicionar'
                     )
                   )
-                ) :createElement(
-                  "div",
-                  { className: "text-center" },
-                 createElement("span", { className: "preloader" })
+                ) : createElement(
+                  'div',
+                  { className: 'text-center' },
+                 createElement('span', { className: 'preloader' })
                 )
               )
             )
@@ -182,17 +187,17 @@ function realWorldForm(createElement) {
       ),
      createElement('div', { data: state.testsTableData })
     )
-  );
+  )
 }
 
-var suite = new Benchmark.Suite('real world form');
+const suite = new Benchmark.Suite('real world form')
 
 // add tests
-suite.add('jsx-base', function() {
+suite.add('jsx-base', () => {
   realWorldForm(baseCreateElement)
-})
-.add('jsx-new', function() {
+}).
+add('jsx-new', () => {
   realWorldForm(newCreateElement)
-});
+})
 
 module.exports = suite

--- a/perf/real-world-form.js
+++ b/perf/real-world-form.js
@@ -1,0 +1,198 @@
+var Benchmark = require('benchmark');
+var baseCreateElement = require('./snnabdom-base').createElement
+var newCreateElement = require('./snnabdom-new').createElement
+
+
+function realWorldForm(createElement) {
+  var state = {};
+  var patient = {get() {}};
+  var clinicalCalcs = {get() {}, isEmpty() {return false}, keys() {return ['a', 'b', 'c', 'd', 'e']}};
+  return createElement(
+    "div",
+    { className: "page compact-content" },
+   createElement(
+      "div",
+      { className: "navbar" },
+     createElement(
+        "div",
+        { className: "navbar-inner" },
+       createElement(
+          "div",
+          { className: "left" },
+         createElement(
+            "a",
+            { href: "#", className: "link icon-only back" },
+           createElement("i", { className: "icon icon-back" })
+          )
+        ),
+       createElement(
+          "div",
+          { className: "center sliding" },
+          "Exames do Paciente"
+        ),
+       createElement("div", { className: "right" })
+      )
+    ),
+   createElement(
+      "div",
+      { className: "page-content" },
+     createElement(
+        "div",
+        { className: "content-block" },
+       createElement(
+          "h3",
+          null,
+          patient.get('name'),          
+          " anos",
+         createElement("br", null),
+         createElement(
+            "span",
+            { className: "header-subtitle" },
+            patient.get('sectorname') || '',
+            " Leito ",
+            (patient.get('bednumber') || '').padStart(2, '0')
+          )
+        )
+      ),
+     createElement(
+        "div",
+        { className: "content-block" },
+       createElement(
+          "div",
+          { className: "row" },
+         createElement(
+            "div",
+            { className: "col" },
+           createElement(
+              "b",
+              null,
+              "Registro"
+            ),
+           createElement("br", null),
+            patient.get('registry'),
+            " ",
+           createElement("br", null)
+          ),
+         createElement(
+            "div",
+            { className: "col" },
+           createElement(
+              "b",
+              null,
+              "Admiss\xE3o Hospitalar"
+            ),
+           createElement("br", null),           
+            " ",
+           createElement("br", null)
+          )
+        )
+      ),
+     createElement(
+        "div",
+        { className: "list-block" },
+       createElement(
+          "ul",
+          null,
+         createElement(
+            "li",
+            { id: "clinical-calcs", className: "accordion-item" },
+           createElement(
+              "a",
+              { href: "#", className: "item-content item-link" },
+             createElement(
+                "div",
+                { className: "item-inner" },
+               createElement(
+                  "div",
+                  { className: "item-title" },
+                  "C\xE1lculos"
+                )
+              )
+            ),
+           createElement(
+              "div",
+              { className: "content-block" },
+             createElement(
+                "div",
+                { className: "accordion-item-content" },
+                clinicalCalcs ? createElement(
+                  "div",
+                  null,
+                  " ",
+                 createElement(
+                    "div",
+                    { className: "card-content" },
+                    !clinicalCalcs.isEmpty() ? createElement(
+                      "div",
+                      { className: "list-block media-list" },
+                      clinicalCalcs.keys().map(function (calcKey) {
+                        return createElement(
+                          "ul",
+                          null,
+                         createElement(
+                            "li",
+                            null,
+                           createElement(
+                              "a",
+                              { href: "#", className: "item-link item-content calc-item", data: { calcKey: calcKey } },
+                             createElement(
+                                "div",
+                                { className: "item-inner" },
+                               createElement(
+                                  "div",
+                                  { className: "item-title-row" },
+                                 createElement(
+                                    "div",
+                                    { className: "item-title" },
+                                    clinicalCalcs.get(calcKey)
+                                  )
+                                ),
+                               createElement(
+                                  "div",
+                                  { className: "item-text" },
+                                  clinicalCalcs.get(calcKey) || ''
+                                )
+                              )
+                            )
+                          )
+                        );
+                      })
+                    ) : 'Nenhum cálculo salvo'
+                  ),
+                 createElement(
+                    "div",
+                    { className: "card-footer" },
+                   createElement("div", null),
+                    " ",
+                   createElement(
+                      "a",
+                      { href: "#", id: "add-calc-item", className: "link" },
+                      "Adicionar"
+                    )
+                  )
+                ) :createElement(
+                  "div",
+                  { className: "text-center" },
+                 createElement("span", { className: "preloader" })
+                )
+              )
+            )
+          )
+        )
+      ),
+     createElement('div', { data: state.testsTableData })
+    )
+  );
+}
+
+var suite = new Benchmark.Suite('real world form');
+
+// add tests
+suite.add('jsx-base', function() {
+  realWorldForm(baseCreateElement)
+})
+.add('jsx-new', function() {
+  realWorldForm(newCreateElement)
+});
+
+module.exports = suite

--- a/perf/run.js
+++ b/perf/run.js
@@ -1,0 +1,41 @@
+var Benchmark = require('benchmark');
+var noProps = require('./no-props');
+var simpleProps = require('./simple-props');
+var objectProps = require('./modules-object-props');
+var attributeProps = require('./modules-attribute-props');
+var realForm = require('./real-world-form');
+
+var suites = []
+
+function runNextSuite() {
+  if (suites.length) {  
+    suites.shift().run({ 'async': true });
+  } else {
+    console.log('\nAll benchmarks complete');
+  }
+}
+
+function addSuite(suite) {
+  suites.push(suite);
+  suite.on('start', function(event) {
+    console.log('\nBenchmarking', event.currentTarget.name);
+  })
+  .on('cycle', function(event) {
+    console.log(String(event.target));
+  })
+  .on('complete', function(event) {
+    const fastest = this.filter('fastest').map('name');
+    const fastestJSX = this.filter(bench => bench.name.indexOf('jsx') !== -1).filter('fastest').map('name');
+    console.log(event.currentTarget.name, '- fastest is ' + fastest, '  fastest JSX is ', fastestJSX);
+    runNextSuite()
+  });  
+}
+
+addSuite(noProps);
+addSuite(simpleProps);
+addSuite(objectProps);
+addSuite(attributeProps);
+addSuite(realForm);
+
+
+runNextSuite()

--- a/perf/run.js
+++ b/perf/run.js
@@ -1,41 +1,39 @@
-var Benchmark = require('benchmark');
-var noProps = require('./no-props');
-var simpleProps = require('./simple-props');
-var objectProps = require('./modules-object-props');
-var attributeProps = require('./modules-attribute-props');
-var realForm = require('./real-world-form');
+const noProps = require('./no-props')
+const simpleProps = require('./simple-props')
+const objectProps = require('./modules-object-props')
+const attributeProps = require('./modules-attribute-props')
+const realForm = require('./real-world-form')
 
-var suites = []
+const suites = []
 
 function runNextSuite() {
-  if (suites.length) {  
-    suites.shift().run({ 'async': true });
+  if (suites.length !== 0) {
+    suites.shift().run({ async: true })
   } else {
-    console.log('\nAll benchmarks complete');
+    console.log('\nAll benchmarks complete')
   }
 }
 
 function addSuite(suite) {
-  suites.push(suite);
-  suite.on('start', function(event) {
-    console.log('\nBenchmarking', event.currentTarget.name);
-  })
-  .on('cycle', function(event) {
-    console.log(String(event.target));
-  })
-  .on('complete', function(event) {
-    const fastest = this.filter('fastest').map('name');
-    const fastestJSX = this.filter(bench => bench.name.indexOf('jsx') !== -1).filter('fastest').map('name');
-    console.log(event.currentTarget.name, '- fastest is ' + fastest, '  fastest JSX is ', fastestJSX);
+  suites.push(suite)
+  suite.on('start', (event) => {
+    console.log('\nBenchmarking', event.currentTarget.name)
+  }).
+  on('cycle', (event) => {
+    console.log(String(event.target))
+  }).
+  on('complete', function (event) {
+    const fastest = this.filter('fastest').map('name')
+    const fastestJSX = this.filter((bench) => bench.name.indexOf('jsx') !== -1).filter('fastest').map('name')
+    console.log(event.currentTarget.name, '- fastest is ' + fastest, '  fastest JSX is ', fastestJSX)
     runNextSuite()
-  });  
+  })
 }
 
-addSuite(noProps);
-addSuite(simpleProps);
-addSuite(objectProps);
-addSuite(attributeProps);
-addSuite(realForm);
-
+addSuite(noProps)
+addSuite(simpleProps)
+addSuite(objectProps)
+addSuite(attributeProps)
+addSuite(realForm)
 
 runNextSuite()

--- a/perf/simple-props.js
+++ b/perf/simple-props.js
@@ -1,33 +1,35 @@
-var Benchmark = require('benchmark');
-var h = require('snabbdom/h').default;
-var baseCreateElement = require('./snnabdom-base').createElement
-var newCreateElement = require('./snnabdom-new').createElement
+/* eslint import/no-unresolved: 0 */
 
-function simplePropsHyper () {
-  return h('div', {props: {href: 'xxxxx', target: 'route'}}, [
-    h('span', {props: {name: 'x', value: 1}}, 'Hello'),
-    h('span', {props: {name: 'y', value: 2}}, 'World')
+const Benchmark = require('benchmark')
+const h = require('snabbdom/h').default
+const baseCreateElement = require('./snnabdom-base').createElement
+const newCreateElement = require('./snnabdom-new').createElement
+
+function simplePropsHyper() {
+  return h('div', { props: { href: 'xxxxx', target: 'route' } }, [
+    h('span', { props: { name: 'x', value: 1 } }, 'Hello'),
+    h('span', { props: { name: 'y', value: 2 } }, 'World')
   ])
 }
 
-function simpleProps (createElement) {
-  return createElement('div', {href: 'xxxxx', target: 'route'}, [
-    createElement('span', {name: 'x', value: 1}, 'Hello'),
-    createElement('span', {name: 'y', value: 2}, 'World')
+function simpleProps(createElement) {
+  return createElement('div', { href: 'xxxxx', target: 'route' }, [
+    createElement('span', { name: 'x', value: 1 }, 'Hello'),
+    createElement('span', { name: 'y', value: 2 }, 'World')
   ])
 }
 
-var suite = new Benchmark.Suite('simple props');
+const suite = new Benchmark.Suite('simple props')
 
 // add tests
-suite.add('hyperscript', function() {
+suite.add('hyperscript', () => {
   simplePropsHyper()
-})
-.add('jsx-base', function() {
+}).
+add('jsx-base', () => {
   simpleProps(baseCreateElement)
-})
-.add('jsx-new', function() {
+}).
+add('jsx-new', () => {
   simpleProps(newCreateElement)
-});
+})
 
 module.exports = suite

--- a/perf/simple-props.js
+++ b/perf/simple-props.js
@@ -1,0 +1,33 @@
+var Benchmark = require('benchmark');
+var h = require('snabbdom/h').default;
+var baseCreateElement = require('./snnabdom-base').createElement
+var newCreateElement = require('./snnabdom-new').createElement
+
+function simplePropsHyper () {
+  return h('div', {props: {href: 'xxxxx', target: 'route'}}, [
+    h('span', {props: {name: 'x', value: 1}}, 'Hello'),
+    h('span', {props: {name: 'y', value: 2}}, 'World')
+  ])
+}
+
+function simpleProps (createElement) {
+  return createElement('div', {href: 'xxxxx', target: 'route'}, [
+    createElement('span', {name: 'x', value: 1}, 'Hello'),
+    createElement('span', {name: 'y', value: 2}, 'World')
+  ])
+}
+
+var suite = new Benchmark.Suite('simple props');
+
+// add tests
+suite.add('hyperscript', function() {
+  simplePropsHyper()
+})
+.add('jsx-base', function() {
+  simpleProps(baseCreateElement)
+})
+.add('jsx-new', function() {
+  simpleProps(newCreateElement)
+});
+
+module.exports = suite

--- a/src/fn.js
+++ b/src/fn.js
@@ -29,10 +29,18 @@ export const mapObject = (obj, fn) => entries(obj).map(
 )
 
 export const deepifyKeys = (obj) => mapObject(obj,
-  ([key, val]) => key.split('-').reverse().reduce(
-    (object, key) => ({ [key]: object }),
-    val
-  )
+  ([key, val]) => {
+    let dashIndex = key.indexOf('-')
+    if (dashIndex > -1) {
+      return {
+        [key.slice(0, dashIndex)]: {
+          [key.slice(dashIndex + 1)]: val
+        }
+      }
+    } else {
+      return {[key]: val}
+    }
+  }
 )
 
 export const renameMod = (name) => {

--- a/src/fn.js
+++ b/src/fn.js
@@ -30,16 +30,15 @@ export const mapObject = (obj, fn) => entries(obj).map(
 
 export const deepifyKeys = (obj) => mapObject(obj,
   ([key, val]) => {
-    let dashIndex = key.indexOf('-')
+    const dashIndex = key.indexOf('-')
     if (dashIndex > -1) {
       return {
         [key.slice(0, dashIndex)]: {
           [key.slice(dashIndex + 1)]: val
         }
       }
-    } else {
-      return {[key]: val}
     }
+    return { [key]: val }
   }
 )
 

--- a/src/fn.js
+++ b/src/fn.js
@@ -32,10 +32,11 @@ export const deepifyKeys = (obj) => mapObject(obj,
   ([key, val]) => {
     const dashIndex = key.indexOf('-')
     if (dashIndex > -1) {
+      const moduleData = {
+        [key.slice(dashIndex + 1)]: val
+      }
       return {
-        [key.slice(0, dashIndex)]: {
-          [key.slice(dashIndex + 1)]: val
-        }
+        [key.slice(0, dashIndex)]: moduleData
       }
     }
     return { [key]: val }

--- a/test/snabbdom-specs/vnode-class-names/actual.js
+++ b/test/snabbdom-specs/vnode-class-names/actual.js
@@ -2,5 +2,5 @@
 import { isVisible, isEnabled } from './neutral'
 
 export default (createElement) => {
-  return createElement('div', { 'class-visible': isVisible, 'class-enabled': isEnabled })
+  return createElement('div', { 'class-visible': isVisible, 'class-enabled': isEnabled, 'class-alert-danger': true })
 }

--- a/test/snabbdom-specs/vnode-class-names/expected.js
+++ b/test/snabbdom-specs/vnode-class-names/expected.js
@@ -3,6 +3,6 @@ import { isVisible, isEnabled } from './neutral'
 
 export default (h) => {
   return h('div', {
-    class: { visible: isVisible, enabled: isEnabled }
+    class: { visible: isVisible, enabled: isEnabled, 'alert-danger': true }
   }, [])
 }

--- a/test/snabbdom-specs/vnode-style/actual.js
+++ b/test/snabbdom-specs/vnode-style/actual.js
@@ -1,4 +1,4 @@
 
 export default (createElement) => {
-  return createElement('div', { 'style-color': 'red' })
+  return createElement('div', { 'style-color': 'red', 'style-background-color': 'blue' })
 }

--- a/test/snabbdom-specs/vnode-style/expected.js
+++ b/test/snabbdom-specs/vnode-style/expected.js
@@ -1,6 +1,6 @@
 
 export default (h) => {
   return h('div', {
-    style: { color: 'red' }
+    style: { color: 'red', 'background-color': 'blue' }
   }, [])
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1316,6 +1316,12 @@ debug@^2.1.1, debug@^2.2.0:
   dependencies:
     ms "0.7.3"
 
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -2858,6 +2864,10 @@ ms@0.7.3, ms@^0.7.1:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.3.tgz#708155a5e44e33f5fd0fc53e81d0d40a91be1fff"
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
 multimatch@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
@@ -3580,6 +3590,12 @@ shelljs@^0.7.5:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+simple-git@^1.92.0:
+  version "1.92.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.92.0.tgz#6061468eb7d19f0141078fc742e62457e910f547"
+  dependencies:
+    debug "^3.1.0"
 
 slash@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,6 +893,13 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+benchmark@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
+  dependencies:
+    lodash "^4.17.4"
+    platform "^1.3.3"
+
 binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
@@ -2710,6 +2717,10 @@ lodash@^4.0.0, lodash@^4.13.1, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^4.17.4:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
@@ -3174,6 +3185,10 @@ pkg-up@^1.0.0:
   resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-1.0.0.tgz#3e08fb461525c4421624a33b9f7e6d0af5b05a26"
   dependencies:
     find-up "^1.0.0"
+
+platform@^1.3.3:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.5.tgz#fb6958c696e07e2918d2eeda0f0bc9448d733444"
 
 plur@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,19 +47,23 @@ acorn-jsx@^3.0.0, acorn-jsx@^3.0.1:
   dependencies:
     acorn "^3.0.4"
 
-acorn-object-spread@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-object-spread/-/acorn-object-spread-1.0.0.tgz#48ead0f4a8eb16995a17a0db9ffc6acaada4ba68"
+acorn5-object-spread@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/acorn5-object-spread/-/acorn5-object-spread-4.0.0.tgz#d5758081eed97121ab0be47e31caaef2aa399697"
   dependencies:
-    acorn "^3.1.0"
+    acorn "^5.1.2"
 
-acorn@^3.0.4, acorn@^3.1.0, acorn@^3.3.0:
+acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
 acorn@^5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
+
+acorn@^5.1.2:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
 
 ajv-keywords@^1.0.0:
   version "1.5.1"
@@ -105,6 +109,12 @@ ansi-styles@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.0.0.tgz#5404e93a544c4fec7f048262977bebfe3155e0c1"
   dependencies:
     color-convert "^1.0.0"
+
+ansi-styles@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
 
 ansi-styles@~1.0.0:
   version "1.0.0"
@@ -944,17 +954,18 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-buble@^0.15.2:
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/buble/-/buble-0.15.2.tgz#547fc47483f8e5e8176d82aa5ebccb183b02d613"
+buble@^0.17.3:
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/buble/-/buble-0.17.3.tgz#b30e281054aa619da5e7b0530ac99fcf309bee67"
   dependencies:
-    acorn "^3.3.0"
+    acorn "^5.1.2"
     acorn-jsx "^3.0.1"
-    acorn-object-spread "^1.0.0"
-    chalk "^1.1.3"
-    magic-string "^0.14.0"
+    acorn5-object-spread "^4.0.0"
+    chalk "^2.1.0"
+    magic-string "^0.22.4"
     minimist "^1.2.0"
     os-homedir "^1.0.1"
+    vlq "^0.2.2"
 
 buf-compare@^1.0.0:
   version "1.0.1"
@@ -1039,6 +1050,14 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
 
 chokidar@^1.4.2:
   version "1.6.1"
@@ -1125,6 +1144,12 @@ code-point-at@^1.0.0:
 color-convert@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  dependencies:
+    color-name "^1.1.1"
+
+color-convert@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
   dependencies:
     color-name "^1.1.1"
 
@@ -2715,9 +2740,9 @@ lru-cache@^4.0.0, lru-cache@^4.0.1:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-magic-string@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.14.0.tgz#57224aef1701caeed273b17a39a956e72b172462"
+magic-string@^0.22.4:
+  version "0.22.4"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.4.tgz#31039b4e40366395618c1d6cf8193c53917475ff"
   dependencies:
     vlq "^0.2.1"
 
@@ -3703,6 +3728,12 @@ supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
+supports-color@^4.0.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  dependencies:
+    has-flag "^2.0.0"
+
 symbol-observable@^0.2.2:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
@@ -3937,6 +3968,10 @@ verror@1.3.6:
 vlq@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.2.tgz#e316d5257b40b86bb43cb8d5fea5d7f54d6b0ca1"
+
+vlq@^0.2.2:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
 
 which@^1.2.8, which@^1.2.9:
   version "1.2.14"


### PR DESCRIPTION
Add scripts that compares performance of the current branch checked in the local repository and a base one (develop).

Steps:
 * builds current branch
 * checkout develop
 * builds develop branch
 * checkout current branch
 * run perf suites based on benchmark.js

Add two npm scripts: 
  * perf:all -> build the two branches and run perf suite
  * perf -> run perf suite

This PR contains changes from #27 

Here is the output of perf suite comparing #27 and develop:

Benchmarking no props
hyperscript x 13,230,387 ops/sec ±5.07% (91 runs sampled)
jsx-base x 699,560 ops/sec ±2.24% (98 runs sampled)
jsx-new x 676,120 ops/sec ±2.98% (93 runs sampled)
no props - fastest is hyperscript   fastest JSX is  [ 'jsx-base' ]

Benchmarking simple props
hyperscript x 13,216,166 ops/sec ±0.73% (98 runs sampled)
jsx-base x 41,596 ops/sec ±0.76% (92 runs sampled)
jsx-new x 45,047 ops/sec ±0.57% (98 runs sampled)
simple props - fastest is hyperscript   fastest JSX is  [ 'jsx-new' ]

Benchmarking module object props
hyperscript x 9,655,921 ops/sec ±0.62% (101 runs sampled)
jsx-base x 41,222 ops/sec ±2.70% (97 runs sampled)
jsx-new x 34,262 ops/sec ±4.33% (82 runs sampled)
module object props - fastest is hyperscript   fastest JSX is  [ 'jsx-base' ]

Benchmarking modules attribute props
hyperscript x 7,928,043 ops/sec ±5.80% (81 runs sampled)
jsx-base x 28,325 ops/sec ±2.04% (89 runs sampled)
jsx-new x 29,938 ops/sec ±1.11% (102 runs sampled)
modules attribute props - fastest is hyperscript   fastest JSX is  [ 'jsx-new' ]

Benchmarking real world form
jsx-base x 2,844 ops/sec ±1.19% (99 runs sampled)
jsx-new x 3,024 ops/sec ±0.66% (101 runs sampled)
real world form - fastest is jsx-new   fastest JSX is  [ 'jsx-new' ]

All benchmarks complete

