### PR TITLE
Optimize mapObject

### DIFF
--- a/dist/index.es6.js
+++ b/dist/index.es6.js
@@ -39,35 +39,21 @@ var assign = function () {
   return _extend.apply(void 0, [ false ].concat( objs ));
 };
 
-var entries = function (obj) { return Object.keys(obj).map(
-  function (key) { return [key, obj[key]]; }
-); };
-
-
-
 var flatten = function (arr) { return arr.reduce(
   function (acc, curr) { return !array(curr) ? acc.concat( [curr]) :
     acc.concat( flatten(curr)); },
   []
 ); };
 
-var mapObject = function (obj, fn) { return entries(obj).map(
-  function (ref) {
-    var key = ref[0];
-    var val = ref[1];
-
-    return fn([key, val]);
-  }
+var mapObject = function (obj, fn) { return Object.keys(obj).map(
+  function (key) { return fn(key, obj[key]); }
 ).reduce(
   function (acc, curr) { return extend(acc, curr); },
   {}
 ); };
 
 var deepifyKeys = function (obj) { return mapObject(obj,
-  function (ref) {
-    var key = ref[0];
-    var val = ref[1];
-
+  function (key, val) {
     var dashIndex = key.indexOf('-');
     if (dashIndex > -1) {
       var moduleData = {};
@@ -88,32 +74,17 @@ var renameMod = function (name) {
 };
 
 var flatifyKeys = function (obj) { return mapObject(obj,
-  function (ref) {
-    var mod = ref[0];
-    var data = ref[1];
-
-    return !object(data) ? (( obj = {}, obj[mod] = data, obj )) : mapObject(
+  function (mod, data) { return !object(data) ? (( obj = {}, obj[mod] = data, obj )) : mapObject(
     flatifyKeys(data),
-    function (ref) {
-      var key = ref[0];
-      var val = ref[1];
-
-      return (( obj = {}, obj[(mod + "-" + key)] = val, obj ))
-      var obj;
-    }
+    function (key, val) { return (( obj = {}, obj[(mod + "-" + key)] = val, obj ))
+      var obj; }
   )
-    var obj;
-  }
+    var obj; }
 ); };
 
 var omit = function (key, obj) { return mapObject(obj,
-  function (ref) {
-    var mod = ref[0];
-    var data = ref[1];
-
-    return mod !== key ? (( obj = {}, obj[mod] = data, obj )) : {}
-    var obj;
-  }
+  function (mod, data) { return mod !== key ? (( obj = {}, obj[mod] = data, obj )) : {}
+    var obj; }
 ); };
 
 // Const fnName = (...params) => guard ? default : ...
@@ -140,23 +111,15 @@ var considerSvg = function (vnode$$1) { return !svg(vnode$$1) ? vnode$$1 :
   ); };
 
 var considerData = function (data) { return mapObject(
-  mapObject(data, function (ref) {
-    var mod = ref[0];
-    var data = ref[1];
-
+  mapObject(data, function (mod, data) {
     var key = renameMod(mod);
     return (( obj = {}, obj[key] = data, obj ))
     var obj;
   }),
-  function (ref) {
-    var mod = ref[0];
-    var data = ref[1];
-
-    return mod !== 'data' ? ( obj = {}, obj[mod] = data, obj ) :
+  function (mod, data) { return mod !== 'data' ? ( obj = {}, obj[mod] = data, obj ) :
     flatifyKeys(( obj$1 = {}, obj$1[mod] = data, obj$1 ))
     var obj;
-    var obj$1;
-  }
+    var obj$1; }
 ); };
 
 var considerAria = function (data) { return data.attrs || data.aria ? omit('aria',
@@ -166,30 +129,20 @@ var considerAria = function (data) { return data.attrs || data.aria ? omit('aria
 ) : data; };
 
 var considerProps = function (data) { return mapObject(data,
-  function (ref) {
-    var key = ref[0];
-    var val = ref[1];
-
-    return object(val) ? ( obj = {}, obj[key] = val, obj ) :
+  function (key, val) { return object(val) ? ( obj = {}, obj[key] = val, obj ) :
     { props: ( obj$1 = {}, obj$1[key] = val, obj$1 ) }
     var obj;
-    var obj$1;
-  }
+    var obj$1; }
 ); };
 
 var rewrites = ['for', 'role', 'tabindex'];
 
 var considerAttrs = function (data) { return mapObject(data,
-    function (ref) {
-      var key = ref[0];
-      var data = ref[1];
-
-      return !rewrites.includes(key) ? ( obj = {}, obj[key] = data, obj ) : {
+    function (key, data) { return !rewrites.includes(key) ? ( obj = {}, obj[key] = data, obj ) : {
       attrs: extend(data.attrs, ( obj$1 = {}, obj$1[key] = data, obj$1 ))
     }
       var obj;
-      var obj$1;
-  }
+      var obj$1; }
 ); };
 
 var considerKey = function (data) { return omit('key', data); };

--- a/dist/index.js
+++ b/dist/index.js
@@ -45,35 +45,21 @@ var assign = function () {
   return _extend.apply(void 0, [ false ].concat( objs ));
 };
 
-var entries = function (obj) { return Object.keys(obj).map(
-  function (key) { return [key, obj[key]]; }
-); };
-
-
-
 var flatten = function (arr) { return arr.reduce(
   function (acc, curr) { return !array(curr) ? acc.concat( [curr]) :
     acc.concat( flatten(curr)); },
   []
 ); };
 
-var mapObject = function (obj, fn) { return entries(obj).map(
-  function (ref) {
-    var key = ref[0];
-    var val = ref[1];
-
-    return fn([key, val]);
-  }
+var mapObject = function (obj, fn) { return Object.keys(obj).map(
+  function (key) { return fn(key, obj[key]); }
 ).reduce(
   function (acc, curr) { return extend(acc, curr); },
   {}
 ); };
 
 var deepifyKeys = function (obj) { return mapObject(obj,
-  function (ref) {
-    var key = ref[0];
-    var val = ref[1];
-
+  function (key, val) {
     var dashIndex = key.indexOf('-');
     if (dashIndex > -1) {
       var moduleData = {};
@@ -94,32 +80,17 @@ var renameMod = function (name) {
 };
 
 var flatifyKeys = function (obj) { return mapObject(obj,
-  function (ref) {
-    var mod = ref[0];
-    var data = ref[1];
-
-    return !object(data) ? (( obj = {}, obj[mod] = data, obj )) : mapObject(
+  function (mod, data) { return !object(data) ? (( obj = {}, obj[mod] = data, obj )) : mapObject(
     flatifyKeys(data),
-    function (ref) {
-      var key = ref[0];
-      var val = ref[1];
-
-      return (( obj = {}, obj[(mod + "-" + key)] = val, obj ))
-      var obj;
-    }
+    function (key, val) { return (( obj = {}, obj[(mod + "-" + key)] = val, obj ))
+      var obj; }
   )
-    var obj;
-  }
+    var obj; }
 ); };
 
 var omit = function (key, obj) { return mapObject(obj,
-  function (ref) {
-    var mod = ref[0];
-    var data = ref[1];
-
-    return mod !== key ? (( obj = {}, obj[mod] = data, obj )) : {}
-    var obj;
-  }
+  function (mod, data) { return mod !== key ? (( obj = {}, obj[mod] = data, obj )) : {}
+    var obj; }
 ); };
 
 // Const fnName = (...params) => guard ? default : ...
@@ -146,23 +117,15 @@ var considerSvg = function (vnode$$1) { return !svg(vnode$$1) ? vnode$$1 :
   ); };
 
 var considerData = function (data) { return mapObject(
-  mapObject(data, function (ref) {
-    var mod = ref[0];
-    var data = ref[1];
-
+  mapObject(data, function (mod, data) {
     var key = renameMod(mod);
     return (( obj = {}, obj[key] = data, obj ))
     var obj;
   }),
-  function (ref) {
-    var mod = ref[0];
-    var data = ref[1];
-
-    return mod !== 'data' ? ( obj = {}, obj[mod] = data, obj ) :
+  function (mod, data) { return mod !== 'data' ? ( obj = {}, obj[mod] = data, obj ) :
     flatifyKeys(( obj$1 = {}, obj$1[mod] = data, obj$1 ))
     var obj;
-    var obj$1;
-  }
+    var obj$1; }
 ); };
 
 var considerAria = function (data) { return data.attrs || data.aria ? omit('aria',
@@ -172,30 +135,20 @@ var considerAria = function (data) { return data.attrs || data.aria ? omit('aria
 ) : data; };
 
 var considerProps = function (data) { return mapObject(data,
-  function (ref) {
-    var key = ref[0];
-    var val = ref[1];
-
-    return object(val) ? ( obj = {}, obj[key] = val, obj ) :
+  function (key, val) { return object(val) ? ( obj = {}, obj[key] = val, obj ) :
     { props: ( obj$1 = {}, obj$1[key] = val, obj$1 ) }
     var obj;
-    var obj$1;
-  }
+    var obj$1; }
 ); };
 
 var rewrites = ['for', 'role', 'tabindex'];
 
 var considerAttrs = function (data) { return mapObject(data,
-    function (ref) {
-      var key = ref[0];
-      var data = ref[1];
-
-      return !rewrites.includes(key) ? ( obj = {}, obj[key] = data, obj ) : {
+    function (key, data) { return !rewrites.includes(key) ? ( obj = {}, obj[key] = data, obj ) : {
       attrs: extend(data.attrs, ( obj$1 = {}, obj$1[key] = data, obj$1 ))
     }
       var obj;
-      var obj$1;
-  }
+      var obj$1; }
 ); };
 
 var considerKey = function (data) { return omit('key', data); };

--- a/src/fn.js
+++ b/src/fn.js
@@ -7,14 +7,6 @@ export const extend = (...objs) => _extend(true, ...objs)
 
 export const assign = (...objs) => _extend(false, ...objs)
 
-export const entries = (obj) => Object.keys(obj).map(
-  (key) => [key, obj[key]]
-)
-
-export const values = (obj) => Object.keys(obj).map(
-  (key) => obj[key]
-)
-
 export const flatten = (arr) => arr.reduce(
   (acc, curr) => !is.array(curr) ? [...acc, curr] :
     [...acc, ...flatten(curr)],

--- a/src/fn.js
+++ b/src/fn.js
@@ -21,15 +21,14 @@ export const flatten = (arr) => arr.reduce(
   []
 )
 
-export const mapObject = (obj, fn) => entries(obj).map(
-  ([key, val]) => fn([key, val])
-).reduce(
-  (acc, curr) => extend(acc, curr),
-  {}
-)
+export const mapObject = (obj, fn) => {
+  return Object.keys(obj)
+    .map(key => fn(key, obj[key]))
+    .reduce((acc, curr) => extend(acc, curr), {})
+}
 
 export const deepifyKeys = (obj) => mapObject(obj,
-  ([key, val]) => {
+  (key, val) => {
     const dashIndex = key.indexOf('-')
     if (dashIndex > -1) {
       const moduleData = {
@@ -51,12 +50,12 @@ export const renameMod = (name) => {
 }
 
 export const flatifyKeys = (obj) => mapObject(obj,
-  ([mod, data]) => !is.object(data) ? ({ [mod]: data }) : mapObject(
+  (mod, data) => !is.object(data) ? ({ [mod]: data }) : mapObject(
     flatifyKeys(data),
-    ([key, val]) => ({ [`${mod}-${key}`]: val })
+    (key, val) => ({ [`${mod}-${key}`]: val })
   )
 )
 
 export const omit = (key, obj) => mapObject(obj,
-  ([mod, data]) => mod !== key ? ({ [mod]: data }) : {}
+  (mod, data) => mod !== key ? ({ [mod]: data }) : {}
 )

--- a/src/fn.js
+++ b/src/fn.js
@@ -13,11 +13,12 @@ export const flatten = (arr) => arr.reduce(
   []
 )
 
-export const mapObject = (obj, fn) => {
-  return Object.keys(obj)
-    .map(key => fn(key, obj[key]))
-    .reduce((acc, curr) => extend(acc, curr), {})
-}
+export const mapObject = (obj, fn) => Object.keys(obj).map(
+  (key) => fn(key, obj[key])
+).reduce(
+  (acc, curr) => extend(acc, curr),
+  {}
+)
 
 export const deepifyKeys = (obj) => mapObject(obj,
   (key, val) => {

--- a/src/index.js
+++ b/src/index.js
@@ -26,11 +26,11 @@ const considerSvg = (vnode) => !is.svg(vnode) ? vnode :
   )
 
 const considerData = (data) => fn.mapObject(
-  fn.mapObject(data, ([mod, data]) => {
+  fn.mapObject(data, (mod, data) => {
     const key = fn.renameMod(mod)
     return ({ [key]: data })
   }),
-  ([mod, data]) => mod !== 'data' ? { [mod]: data } :
+  (mod, data) => mod !== 'data' ? { [mod]: data } :
     fn.flatifyKeys({ [mod]: data })
 )
 
@@ -41,14 +41,14 @@ const considerAria = (data) => data.attrs || data.aria ? fn.omit('aria',
 ) : data
 
 const considerProps = (data) => fn.mapObject(data,
-  ([key, val]) => is.object(val) ? { [key]: val } :
+  (key, val) => is.object(val) ? { [key]: val } :
     { props: { [key]: val } }
 )
 
 const rewrites = ['for', 'role', 'tabindex']
 
 const considerAttrs = (data) => fn.mapObject(data,
-    ([key, data]) => !rewrites.includes(key) ? { [key]: data } : {
+    (key, data) => !rewrites.includes(key) ? { [key]: data } : {
       attrs: fn.extend(data.attrs, { [key]: data })
     }
 )


### PR DESCRIPTION
It changes mapObject implementation to pass key and value arguments as separated params instead of an array. It helps by eliminating the need to create a temporary array and destructuring later. 

Allows to delete entries and values helpers