### PR TITLE
fix a bug when text is number 0

### DIFF
--- a/dist/index.es6.js
+++ b/dist/index.es6.js
@@ -169,7 +169,7 @@ var createElementWithModules = function (modules) {
     return considerSvg({
       sel: sel,
       data: data ? sanitizeData(data, modules) : {},
-      children: text$$1 ? undefined : sanitizeChildren(children),
+      children: !undefinedv(text$$1) ? undefined : sanitizeChildren(children),
       text: text$$1,
       elm: undefined,
       key: data ? data.key : undefined

--- a/dist/index.js
+++ b/dist/index.js
@@ -175,7 +175,7 @@ var createElementWithModules = function (modules) {
     return considerSvg({
       sel: sel,
       data: data ? sanitizeData(data, modules) : {},
-      children: text$$1 ? undefined : sanitizeChildren(children),
+      children: !undefinedv(text$$1) ? undefined : sanitizeChildren(children),
       text: text$$1,
       elm: undefined,
       key: data ? data.key : undefined

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ export const createElementWithModules = (modules) => {
     return considerSvg({
       sel,
       data: data ? sanitizeData(data, modules) : {},
-      children: text ? undefined : sanitizeChildren(children),
+      children: !is.undefinedv(text) ? undefined : sanitizeChildren(children),
       text,
       elm: undefined,
       key: data ? data.key : undefined


### PR DESCRIPTION
when text is number 0, an unnecessary child node will be created 
this will cause snabbdom to remove non-exist child element when said number is modified from other number to 0