### PR TITLE
Fix wrong recognized dataset attribute

### DIFF
--- a/src/fn.js
+++ b/src/fn.js
@@ -37,6 +37,11 @@ export const deepifyKeys = (obj, modules) => mapObject(obj,
       return {
         [key.slice(0, dashIndex)]: moduleData
       }
+    } else if (key === 'dataset' && modules.data !== undefined) {
+      // Allow users to specify data-* attributes with `dataset`
+      return {
+        data: { ...val }
+      }
     }
     return { [key]: val }
   }


### PR DESCRIPTION
Without this checking, users can't specify data-* attributes with
`dataset` from JSX and will be recognized as other modules. But,
`dataset` should be handled as `data` module.

Ex.

When I used `dataset` modules and `props` modules in Cycle.js, I will get `TypeError: "setting getter-only property "dataset""` because the `dataset` attribute is seen as `props`.