### PR TITLE
Fix zero in text node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ const rewriteModules = (data, modules) => fn.mapObject(data, (key, val) => {
 
 const sanitizeData = (data, modules) => considerSvg(rewriteModules(fn.deepifyKeys(data, modules), modules))
 
-const sanitizeText = (children) => children.length > 1 || !is.text(children[0]) ? undefined : children[0]
+const sanitizeText = (children) => children.length > 1 || !is.text(children[0]) ? undefined : children[0].toString()
 
 const sanitizeChildren = (children) => fn.reduceDeep(children, (acc, child) => {
   const vnode = is.vnode(child) ? child : createTextElement(child)


### PR DESCRIPTION
Numbers in text nodes are not converted to strings, so the number zero is treated as 'falsy' by snabbdom.  This can cause problems with dynamically changing values when patching the DOM.

Example:

```javascript
// this works as expected
() => <div>1</div>
// renders to { children: undefined, sel: 'div', text: 1, ... }

// this does not work properly
() => <div>0</div>
// renders to { children: [{ children: undefined, sel: undefined, text: 0, ... }], sel: 'div', text: undefined, ... }
```

The fix in this PR just converts the results of sanitizeText to a string, which fixes the issue with numeric zero

Resolves #43 